### PR TITLE
Don't show the helptext when using -lib

### DIFF
--- a/dmd-script
+++ b/dmd-script
@@ -524,7 +524,7 @@ if ( $print_version ) {
     my $result = system(@cmd);
     errorExit if $result & 0xff; # Give up if can't exec or gdc exited with a signal
     exit 0;
-} elsif (! scalar(@sources) && ! ($link && scalar(@objects))) {
+} elsif (! scalar(@sources) && ! (($link || $lib) && scalar(@objects))) {
     my @cmd = ($gdc, '--version', @out);
     my $result = system(@cmd);
     errorExit if $result & 0xff; # Give up if can't exec or gdc exited with a signal


### PR DESCRIPTION
From https://github.com/dlang/dmd/pull/8111

Essentially this is the problem - as it will always trigger the help text.

```
./dmd-script -lib -of../foo.a oo.o
```
