### PR TITLE
Remove '-gc' and '-property', add '-h'

### DIFF
--- a/dmd-script
+++ b/dmd-script
@@ -126,7 +126,6 @@ Usage:
   -fall-sources  for every source file, semantically process each file preceding it
   -framework ... pass a -framework ... option to gdc
   -g             add symbolic debug info
-  -gc            add symbolic debug info, pretend to be C
   -gs            always emit stack frame
   -gx            add stack stomp code
   -H             generate 'header' file
@@ -352,7 +351,7 @@ while ( $arg_i < scalar(@ARGV) ) {
         push @link_out, '-defaultlib', $1;
     } elsif ( $arg =~ m/^-deps=(.*)$/ ) {
         push @out, (defined($1) ? "-fdeps=$1" : '-fdeps');
-    } elsif ( $arg =~ m/^-g$|^-gc$/ ) {
+    } elsif ( $arg =~ m/^-g$/ ) {
         $debug = 1;
         push @out, '-g';
     } elsif ( $arg =~ m/^-gs$/ ) {

--- a/dmd-script
+++ b/dmd-script
@@ -131,7 +131,7 @@ Usage:
   -H             generate 'header' file
   -Hdhdrdir      write 'header' file to hdrdir directory
   -Hffilename    write 'header' file to filename
-  --help         print help
+  --help|-h      print help
   -Ipath         where to look for imports
   -ignore        ignore unsupported pragmas
   -inline        do function inlining
@@ -368,7 +368,7 @@ while ( $arg_i < scalar(@ARGV) ) {
     } elsif ( $arg =~ m/^-Hf(.*)$/ ) {
         $header = 1;
         $header_file = $1;
-    } elsif ( $arg eq '--help' ) {
+    } elsif ( $arg eq '--help' || $arg eq '-h' ) {
         printUsage;
         exit 0;
     } elsif ($arg eq '-framework' ) {

--- a/dmd-script
+++ b/dmd-script
@@ -149,7 +149,6 @@ Usage:
   -op            do not strip paths from source file
   -pipe          use pipes rather than intermediate files
   -profile       profile runtime performance of generated code
-  -property      enforce property syntax
   -quiet         suppress unnecessary messages
   -q,arg1,...    pass arg1, arg2, etc. to to gdc
   -release       compile release version
@@ -376,8 +375,6 @@ while ( $arg_i < scalar(@ARGV) ) {
         push @link_out, '-framework', $ARGV[$arg_i++];
     } elsif ( $arg eq '-ignore' ) {
         push @out, '-fignore-unknown-pragmas';
-    } elsif ( $arg eq '-property' ) {
-        push @out, '-fproperty';
     } elsif ( $arg =~ m/^-inline$/ ) {
         push @out, '-finline-functions';
     } elsif ( $arg =~ m/^-I(.*)$/ ) {


### PR DESCRIPTION
Just realized that `gdmd` didn't implement `-h`, which I tried to use in one of my script.
The rest is just things I noticed while looking at the help text.