### PR TITLE
Ignore -vcolumns flag

### DIFF
--- a/dmd-script
+++ b/dmd-script
@@ -321,7 +321,7 @@ while ( $arg_i < scalar(@ARGV) ) {
 
     if ($arg eq '-arch' ) {
         push @out, '-arch', $ARGV[$arg_i++];
-    } elsif ( $arg =~ m/^-betterC$/ ) {
+    } elsif ( $arg =~ m/^(-betterC|-vcolumns)$/ ) {
         # ignored
     } elsif ($arg =~ m/^-c$/ ) {
         $link = 0;


### PR DESCRIPTION
It only adds column information to error output, which GDC already does.

Untested, couldn't make this script run locally without errors.

Note: the @arguments.rsp functionality also seems to be broken, but I couldn't figure out what exactly is broken / it seems like it's ignored or it's not being read from.