### PR TITLE
Add -i option

### DIFF
--- a/dmd-script
+++ b/dmd-script
@@ -133,6 +133,7 @@ Usage:
   -Hffilename    write 'header' file to filename
   --help|-h      print help
   -Ipath         where to look for imports
+  -i             include imported modules in the compilation
   -ignore        ignore unsupported pragmas
   -inline        do function inlining
   -Jpath         where to look for string imports
@@ -378,6 +379,8 @@ while ( $arg_i < scalar(@ARGV) ) {
         exit 0;
     } elsif ($arg eq '-framework' ) {
         push @link_out, '-framework', $ARGV[$arg_i++];
+    } elsif ( $arg eq '-i' ) {
+        push @out, '-finclude-imports';
     } elsif ( $arg eq '-ignore' ) {
         push @out, '-fignore-unknown-pragmas';
     } elsif ( $arg =~ m/^-inline$/ ) {

--- a/dmd-script.1
+++ b/dmd-script.1
@@ -63,6 +63,8 @@ where to look for imports
 .I path
 is a ; separated list of paths. Multiple -I's can be used, and the paths are searched in the same order.
 
+.IP -i
+Include imported modules in the compilation, as if they were given on the command line. When this option is enabled, all imported modules are compiled except those that are part of libphobos.
 .IP -ignore
 ignore unsupported pragmas
 .IP -inline


### PR DESCRIPTION
Not fully compatible with dmd as dmd accepts an optional argument for the switch denoting which imports to also be compiled but since gdc-15 the common use case of plain -i is supported.