### PR TITLE
dmd-script.1: Quote multiple-word flag descriptions

### DIFF
--- a/dmd-script.1
+++ b/dmd-script.1
@@ -15,7 +15,7 @@ D interface files
 Object files to link in
 .IP files.a
 Library files to link in
-.IP -arch ...
+.IP "-arch ..."
 pass -arch option to gdc
 .IP -c
 compile only, do not link
@@ -45,7 +45,7 @@ write module dependencies to filename
 pass an -f... option to gdc
 .IP -fall-sources
 for every source file, semantically process each file preceding i
-.IP -framework ...
+.IP "-framework ..."
 pass a -framework ... option to gdc
 .IP -g
 add symbolic debug info


### PR DESCRIPTION
When a flag's summary is made up of multiple words (like `-arch ...`) quote it when passing it to .IP to prevent the second word from disappearing and the indentation from getting messed up for the rest of the document.