### PR TITLE
No longer ignore -betterC

### DIFF
--- a/dmd-script
+++ b/dmd-script
@@ -110,6 +110,7 @@ Usage:
   -allinst       generate code for all template instantiations
   -arch ...      pass an -arch ... option to gdc
   -boundscheck=value    bounds checks on, in \@safe only, or off
+  -betterC       omit generating some runtime information and helper functions
   -c             do not link
   -cov           do code coverage analysis
   -D             generate documentation
@@ -334,7 +335,9 @@ while ( $arg_i < scalar(@ARGV) ) {
 	push @out, '-fall-instantiations'
     } elsif ( $arg eq '-arch' ) {
         push @out, '-arch', $ARGV[$arg_i++];
-    } elsif ( $arg =~ m/^(-betterC|-vcolumns)$/ ) {
+    } elsif ( $arg =~ m/^-betterC$/ ) {
+	push @out, '-fno-druntime'
+    } elsif ( $arg =~ m/^-vcolumns$/ ) {
         # ignored
     } elsif ( $arg =~ m/^-boundscheck=(.*)$/ ) {
 	push @out, "-fbounds-check=$1"

--- a/dmd-script.1
+++ b/dmd-script.1
@@ -21,6 +21,8 @@ generate code for all template instantiations
 pass -arch option to gdc
 .IP -boundscheck=[on|safeonly|off]
 bounds checks on, in @safe only, or off
+.IP -betterC
+omit generating some runtime information and helper functions
 .IP -c
 compile only, do not link
 .IP -cov


### PR DESCRIPTION
gdc implemented -fno-druntime a while back.

I hit this when trying to run the dub testsuite.