### PR TITLE
Ignore -wo

### DIFF
--- a/dmd-script
+++ b/dmd-script
@@ -472,6 +472,8 @@ while ( $arg_i < scalar(@ARGV) ) {
         push @out, "-Werror";
     } elsif ( $arg =~ m/^-wi$/ ) {
         push @out, "-Wall";
+    } elsif ( $arg =~ m/^-wo$/ ) {
+	# ignored
     } elsif ( $arg =~ m/^-quiet$/ ) {
         # ignored
     } elsif ( $arg =~ m/^-q,(.*)$/ ) {


### PR DESCRIPTION
I couldn't find any examples of -wo doing anything for upstream dmd so just ignore it.