### PR TITLE
Fix docs about -version=level and -debug=level

### DIFF
--- a/dmd-script
+++ b/dmd-script
@@ -169,7 +169,7 @@ Usage:
   -verrors=context   (enabled by default) show diagnostic messages with context
   -verrors=spec  show errors from speculative compiles such as __traits(compiles,...)
   --version      print compiler version and exit
-  -version=level compile in version code >= level
+  -version=level compile in version code <= level
   -version=ident compile in version code identified by ident
   -vtemplates    list statistics on template instantiations
   -vtls          list all variables going into thread local storage

--- a/dmd-script.1
+++ b/dmd-script.1
@@ -138,8 +138,9 @@ print compiler version and exit
 .IP -h|--help
 Print the usage information and exit
 .IP -version=level
-compile in version code >= level
-.IP  version=ident
+compile in version code <= level
+.IP -version=ident
+compile in version code identified by ident
 .IP -vtemplates
 list statistics on template instantiations
 .IP -vtls


### PR DESCRIPTION
Although removed in gdc-13, -version and -debug with a integer value are still supported by gdc-12. The documentation, both in this package's help text and man page, as well as in the gdc man page, as well as in the (old) upstream dmd man page say that the -version=level switch is supposed to compile code in blocks >= level, but a simple compile run gives contrary results, those being blocks <= level are compiled. This feature has been removed so no point it thinking too much about it so have the docs document the observed behavior.

Also fix the man page having an incomplete -version=ident entry.