### PR TITLE
dmd-script: Expand @rsp arguments in-place in ARGV

### DIFF
--- a/dmd-script
+++ b/dmd-script
@@ -561,11 +561,11 @@ while ( $arg_i < scalar(@ARGV) ) {
     } elsif ( $arg =~ m/^-.+$/ ) {
         errorExit "unrecognized switch '$arg'";
     } elsif ( $arg =~ m/^\@(.+)$/i ) {
-        # Append response file to end of ARGV.
 	open(my $rsp_fh, "<", $1) or die("Can't read response file: $!");
 	my $rsp = do { local $/; <$rsp_fh> };
         close($rsp_fh);
 
+	my @new_args;
         while (length $rsp) {
             if ($rsp =~ m/^"(([^\\"]|\\.)*(\\\\)*)"\s*/ ) {
                 $arg = $1;
@@ -577,8 +577,10 @@ while ( $arg_i < scalar(@ARGV) ) {
                 $arg = $1;
                 $rsp = $';
             }
-            push @ARGV, $arg;
+            push @new_args, $arg;
         }
+	# Place the response arguments after the @path argument
+	splice @ARGV, $arg_i, 0, @new_args;
     } elsif ( $arg =~ m/^.+\.d$/i ||
               $arg =~ m/^.+\.dd$/i ||
               $arg =~ m/^.+\.di$/i) {


### PR DESCRIPTION
When expanding response files place the extracted arguments in the same spot that the response argument appeared on, in the ARGV array, instead of appending them at the end.

Specifically make `gdmd @args -foo` expand to `gdmd -arg1 -arg2 -foo`, not `gdmd -foo -arg1 -arg2`.

This is especially problematic with then `-run` flag since `gdmd @args -run file` will map to `gdmd -run file -arg1 -arg2` which no longer passes `-arg1 -arg2` to gdc, but to the compiled program.